### PR TITLE
remove remaining pandas import

### DIFF
--- a/gbd_init/feature_extractors.py
+++ b/gbd_init/feature_extractors.py
@@ -12,7 +12,6 @@
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
 
-import pandas as pd
 import os
 import glob
 import warnings


### PR DESCRIPTION
There was still one remaining pandas import, which prevents the current version from being used without having pandas installed.